### PR TITLE
chore: use reusable adoc workflows

### DIFF
--- a/.github/workflows/adocs-build-and-publish-develop.yml
+++ b/.github/workflows/adocs-build-and-publish-develop.yml
@@ -14,35 +14,12 @@ on:
 
 jobs:
   adoc_build:
-    runs-on: ubuntu-latest
     name: asciidoctor build
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild_html
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor-pdf -D docs -o files/veileder-kvantifiserbar-kvalitet.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-github-pages.yaml@main
+    with:
+      program_html: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
+      program_pdf: "asciidoctor-pdf -D docs -o files/veileder-kvantifiserbar-kvalitet.pdf -a lang=nb docs/main.adoc"
+      publish_branch: gh-pages
+      publish_dir: ./docs
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/adocs-build-and-publish-v1-production.yml
+++ b/.github/workflows/adocs-build-and-publish-v1-production.yml
@@ -13,46 +13,20 @@ on:
 
 jobs:
   adoc_build:
-    runs-on: ubuntu-latest
     name: asciidoctor build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          submodules: true
-          fetch-depth: 0
-          ref: v1
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild_html
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor-pdf -D docs -o files/veileder-kvantifiserbar-kvalitet.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Upload files to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@84beeeacd364f310ef6a253bc079354cdf62e5dd
-        id: upload-files
-        with:
-          ontology-type: "guide"
-          ontology: "veileder-kvantifiserbar-kvalitet"
-          host: "https://data.norge.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            docs/index.html text/html nb
-            docs/files/veileder-kvantifiserbar-kvalitet.pdf application/pdf nb files/veileder-kvantifiserbar-kvalitet.pdf
-            docs/images/Digdir.png image/png nb images/Digdir.png
-            docs/images/eksempeldatasett.png image/png nb images/eksempeldatasett.png
-            docs/images/sammenheng.png image/png nb images/sammenheng.png
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v1
+      program_html: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
+      program_pdf: "asciidoctor-pdf -D docs -o files/veileder-kvantifiserbar-kvalitet.pdf -a lang=nb docs/main.adoc"
+      files: |
+        docs/index.html text/html nb
+        docs/files/veileder-kvantifiserbar-kvalitet.pdf application/pdf nb files/veileder-kvantifiserbar-kvalitet.pdf
+        docs/images/Digdir.png image/png nb images/Digdir.png
+        docs/images/eksempeldatasett.png image/png nb images/eksempeldatasett.png
+        docs/images/sammenheng.png image/png nb images/sammenheng.png
+      ontology-type: "guide"
+      ontology: "veileder-kvantifiserbar-kvalitet"
+      host: "https://data.norge.no"
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}


### PR DESCRIPTION
# Summary
Migrate the two AsciiDoc build/publish workflows to call the central Informasjonsforvaltning/workflows reusable workflows.

- develop → publish to GitHub Pages via `specification-github-pages.yaml@main`
- v1 → publish to data.norge.no via `specification-upload-files.yaml@main`
- Drop floating `Analog-inc/asciidoctor-action@master` for the centrally-pinned toolchain
- Triggers, inputs, files and secrets preserved verbatim

Note: PDF build failures now block the deploy/upload (no `continue-on-error` in the reusable workflows). v1 needs no separate PR — the develop→v1 merge carries this.